### PR TITLE
fix: skip header on the input file

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -8,7 +8,7 @@ void Parser::count_breakpoints(std::istream &is) {
     nbreakpoints = 0;
     std::string line;
     while (std::getline(is, line)) {
-        if (boost::starts_with(line, "#"))
+        if (boost::starts_with(line, "#") || boost::starts_with(line, "chr"))
             continue;
         nbreakpoints++;
     }


### PR DESCRIPTION
@rjbohlender: It's possible that Garahme and the below lab folk have just been running this with inappropriate input data, but I noticed that our input IDB files have headers that are being counted as a breakpoint.

However, after I noticed this I failed to find anywhere where this value is actually read other than to print it, so this probably doesn't matter.

Skip header lines that start with chr. A better test could be testing if the first character is numeric