### PR TITLE
less branching in Statistic::calculate to see if this speeds things up

### DIFF
--- a/src/statistic.cpp
+++ b/src/statistic.cpp
@@ -45,6 +45,11 @@ Statistic::calculate(std::vector<int> &phenotypes_, double cscs_count, double cs
         int x = phenotypes_[p1];
         int y = phenotypes_[p2];
 
+        if (x < -1 || x > 1 || y < -1 || y > 1) {
+            fmt::print(std::cerr, "Phenotypes: {},{} p1: {} p2: {}\n", x, y, p1, p2);
+            throw(std::runtime_error("ERROR: invalid phenotype in calculate."));
+        }
+
         cscs += ((x == 1) && (y == 1));
         cscn += ((x == 1) && (y == 0));
         cscn += ((x == 0) && (y == 1));


### PR DESCRIPTION
Inline and remove sanity checking for phenotypes in Statistics::calculate to see if less branching speeds things up.

You tell me if this is taking it too far and is pathological to go so primitive, but on my Macbook, on small datasets, this made it absolutely rip. Joint_permute went from ~60% of runtime to ~30%, approx a 2x speedup on that part. This change also may not scale up to the servers or to larger datasets though, so I'm taking a stab at optimizing before profiling a real dataset, which is bad.

https://godbolt.org/ helped confirm that `cscn += ((x == 1) && (y == 0)) || ((x == 0) && (y == 1));` branches but 
```
cscn += ((x == 1) && (y == 0));
cscn += ((x == 0) && (y == 1));
```
does not with -O3 on GCC 11.