### PR TITLE
Add frame pointers for debugging, and build -march=native

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,14 +19,18 @@ find_package(ZLIB REQUIRED)
 
 set(CMAKE_SHARED_MODULE_PREFIX "")
 
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
+if(COMPILER_SUPPORTS_MARCH_NATIVE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+endif()
+
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined" )
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG -fno-omit-frame-pointer")
 
 if (UNIX)
     find_package(LAPACK REQUIRED)
     find_package(BLAS REQUIRED)
-    if (NOT APPLE)
-        set(BLA_STATIC ON)
-    endif()
 endif()
 
 set(PROJECT_SUPPORT_FILES
@@ -77,8 +81,6 @@ add_executable(carvaIBD main.cpp ${PROJECT_SUPPORT_FILES})
 
 target_link_libraries(carvaIBD fmt::fmt-header-only)
 target_link_libraries(carvaIBD pthread)
-target_link_libraries(carvaIBD ${LAPACK_LIBRARIES})
-target_link_libraries(carvaIBD ${BLAS_LIBRARIES})
 target_link_libraries(carvaIBD ${ARMADILLO_LIBRARIES})
 target_link_libraries(carvaIBD ${Python3_LIBRARIES} ${Boost_LIBRARIES})
 target_link_libraries(carvaIBD ${ZLIB_LIBRARIES})


### PR DESCRIPTION
When building release with debug info, set `-fno-omit-frame-pointer` so that we can get stack traces more easily. This lets perf get more complete stack trace info from our own program without the overhead of 

This also builds `-march=native` on platforms that support it. At the very least, I see that it's calling AVX2 functions now, which should be faster.

If Seadragon has a varied CPU setup, we could specifically do something like `-march=skylake-avx512 -mtune=skylake-avx512`. That also could be reaching for performance that isn't there, though.