### PR TITLE
testing better performance - use smaller datatype for phenotype arrays

### DIFF
--- a/src/indexer.hpp
+++ b/src/indexer.hpp
@@ -7,6 +7,7 @@
 
 #define ARMA_DONT_USE_WRAPPER
 
+#include "types.hpp"
 #include "indexsort.hpp"
 #include <armadillo>
 #include <unordered_map>
@@ -27,7 +28,7 @@ struct Indexer {
     arma::uword cont_count;
     arma::uword sz;
     std::vector<std::string> samples;
-    std::vector<int> phenotypes;
+    pheno_vector phenotypes;
     std::vector<arma::sword> transitions;// Transition points between pairing sets
     std::unordered_map<std::string, int> ordered_positions;
     std::unordered_map<std::string, int> ordered_cc_positions;
@@ -42,7 +43,7 @@ struct Indexer {
     Indexer(arma::uword case_count_,
             arma::uword cont_count_,
             std::vector<std::string> samples_,
-            std::vector<int> phenotypes_)
+            pheno_vector phenotypes_)
         : case_count(case_count_), cont_count(cont_count_), sz(samples_.size()), phenotypes(std::move(phenotypes_)),
           samples(std::move(samples_)), case_case(0), case_cont(0), cont_cont(0) {
         setup(case_count_, cont_count_);

--- a/src/phenotypes.hpp
+++ b/src/phenotypes.hpp
@@ -19,7 +19,7 @@ class Phenotypes {
     void build_groups(const std::map<std::vector<bool>, std::vector<arma::uword>> &fill_patterns);
 public:
     std::shared_ptr<std::vector<std::string>> samples;
-    std::vector<std::vector<int>> phenotypes;
+    std::vector<pheno_vector> phenotypes;
     std::shared_ptr<std::vector<Indexer>> indexer;
     std::optional<std::vector<std::vector<arma::uword>>> groups;
 

--- a/src/statistic.cpp
+++ b/src/statistic.cpp
@@ -21,7 +21,7 @@ Statistic::Statistic(arma::sp_colvec data_, Breakpoint bp_, std::shared_ptr<std:
 }
 
 double
-Statistic::calculate(std::vector<int> &phenotypes_, double cscs_count, double cscn_count, double cncn_count, size_t k) {
+Statistic::calculate(pheno_vector &phenotypes_, double cscs_count, double cscn_count, double cncn_count, size_t k) {
     double statistic;
 
     double cscs = 0;
@@ -101,7 +101,7 @@ void Statistic::run() {
     while (permutations.back() < params.nperms) {
         if (groups) {
             for (const auto &groupIndices : *groups) {
-                std::vector<std::vector<int>> phenotypes_tmp;
+                std::vector<pheno_vector> phenotypes_tmp;
                 group_pack(phenotypes, phenotypes_tmp, groupIndices);
                 joint_shuffle(phenotypes_tmp, gen);
                 group_unpack(phenotypes, phenotypes_tmp, groupIndices);
@@ -145,12 +145,12 @@ void Statistic::build_output(std::stringstream &ss) {
     }
 }
 
-void Statistic::group_pack(const std::vector<std::vector<int>> &p_original,
-                           std::vector<std::vector<int>> &p_tmp,
+void Statistic::group_pack(const std::vector<pheno_vector> &p_original,
+                           std::vector<pheno_vector> &p_tmp,
                            const std::vector<arma::uword> &groupIndices) {
     for (auto [i, p] : Enumerate(p_original)) {
         try {
-            p_tmp.emplace_back(std::vector<int>(groupIndices.size(), 0));
+            p_tmp.emplace_back(pheno_vector(groupIndices.size(), 0));
         } catch (std::length_error &e) {
             fmt::print(std::cerr, "Failed to emplace at line {}.", __LINE__);
         }
@@ -162,8 +162,8 @@ void Statistic::group_pack(const std::vector<std::vector<int>> &p_original,
     }
 }
 
-void Statistic::group_unpack(std::vector<std::vector<int>> &p_original,
-                             const std::vector<std::vector<int>> &p_tmp,
+void Statistic::group_unpack(std::vector<pheno_vector> &p_original,
+                             const std::vector<pheno_vector> &p_tmp,
                              const std::vector<arma::uword> &group_indices) {
     for (auto [i, p] : Enumerate(p_tmp)) {
         int x = 0;
@@ -186,7 +186,7 @@ void Statistic::joint_permute() {
     }
 }
 
-void Statistic::joint_shuffle(std::vector<std::vector<int>> &phen, std::mt19937_64 &gen) {
+void Statistic::joint_shuffle(std::vector<pheno_vector> &phen, std::mt19937_64 &gen) {
     for (size_t i = phen[0].size() - 1; i > 0; i--) {
         std::uniform_int_distribution<> dis(0, i);
         int j = dis(gen);
@@ -229,7 +229,7 @@ void Statistic::test_statistic() {
             "case6", "case7", "case8", "case9", "case10",
             "control1", "control2", "control3", "control4", "control5",
             "control6", "control7", "control8", "control9", "control10"};
-    std::vector<int> tphenotypes_{
+    pheno_vector tphenotypes_{
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     Indexer tindexer(10, 10, tsamples, tphenotypes_);
 
@@ -313,7 +313,7 @@ void Statistic::test_group_permutation(unsigned int seed) {
     std::string line;
     arma::uword lineno = 0;
 
-    std::vector<std::vector<int>> tphenotypes;
+    std::vector<pheno_vector> tphenotypes;
 
     while (std::getline(test_data, line)) {
         if (boost::starts_with(line, "#") || lineno == 0) {// Skip the header
@@ -387,7 +387,7 @@ void Statistic::test_group_permutation(unsigned int seed) {
 
     std::mt19937_64 tgen(seed);
     for (const auto &v : *tgroups) {// For each of the set of group indices
-        std::vector<std::vector<int>> tphenotypes_tmp;
+        std::vector<pheno_vector> tphenotypes_tmp;
         group_pack(tphenotypes, tphenotypes_tmp, v);
         joint_shuffle(tphenotypes_tmp, tgen);
         group_unpack(tphenotypes, tphenotypes_tmp, v);

--- a/src/statistic.hpp
+++ b/src/statistic.hpp
@@ -7,6 +7,7 @@
 
 #define ARMA_DONT_USE_WRAPPER
 
+#include "types.hpp"
 #include "breakpoint.hpp"
 #include "indexer.hpp"
 #include "parameters.hpp"
@@ -22,7 +23,7 @@
 class Statistic {
     arma::sp_colvec data;
     std::shared_ptr<std::vector<Indexer>> indexer;
-    std::vector<std::vector<int>> phenotypes;
+    std::vector<pheno_vector> phenotypes;
     Parameters params;
 
     std::shared_ptr<Reporter> reporter;
@@ -34,13 +35,13 @@ class Statistic {
     static void x1(int y, double &cscs, double &cscn);
     static void x0(int y, double &cscn, double &cncn);
     void initialize();
-    static void joint_shuffle(std::vector<std::vector<int>> &phen, std::mt19937_64 &gen);
+    static void joint_shuffle(std::vector<pheno_vector> &phen, std::mt19937_64 &gen);
     void joint_permute();
-    static void group_unpack(std::vector<std::vector<int>> &p_original,
-                             const std::vector<std::vector<int>> &p_tmp,
+    static void group_unpack(std::vector<pheno_vector> &p_original,
+                             const std::vector<pheno_vector> &p_tmp,
                              const std::vector<arma::uword> &group_indices);
-    static void group_pack(const std::vector<std::vector<int>> &p_original,
-                           std::vector<std::vector<int>> &p_tmp,
+    static void group_pack(const std::vector<pheno_vector> &p_original,
+                           std::vector<pheno_vector> &p_tmp,
                            const std::vector<arma::uword> &groupIndices);
     void build_output(std::stringstream &ss);
 
@@ -62,7 +63,7 @@ public:
 
     Statistic(arma::sp_colvec data_, Breakpoint bp_, std::shared_ptr<std::vector<Indexer>> indexer_, std::shared_ptr<Reporter> reporter_, Parameters params_, std::optional<std::vector<std::vector<arma::uword>>> groups_);
 
-    double calculate(std::vector<int> &phenotypes_, double cscs_count, double cscn_count, double cncn_count, size_t k);
+    double calculate(pheno_vector &phenotypes_, double cscs_count, double cscn_count, double cncn_count, size_t k);
 
     void run();
     void cleanup();

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -1,0 +1,9 @@
+#ifndef CARVAIBD_TYPES_HPP
+#define CARVAIBD_TYPES_HPP
+
+#include <cstdint>
+#include <vector>
+
+typedef std::vector<int8_t> pheno_vector;
+
+#endif//CARVAIBD_TYPES_HPP


### PR DESCRIPTION
Try using a smaller datatype for phenotype vector for better cache friendliness.