### PR TITLE
Lower memory usage by cleaning up parser before sorting output

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -171,12 +171,15 @@ int main(int argc, char *argv[]) {
   if (params.verbose) {
 	fmt::print(std::cerr, "Running parser.\n");
   }
-  Phenotypes pheno(params);
-  Parser parser(
-          params,
-          reporter,
-          gmap,
-          pheno);
+
+  {
+    Phenotypes pheno(params);
+    Parser parser(
+            params,
+            reporter,
+            gmap,
+            pheno);
+  }
 
   // Sort output
   fmt::print(std::cerr, "Sorting output.\n");


### PR DESCRIPTION
Reduce peak memory usage by about 5% by de-allocating the parser before we start sorting output. This will make it easier to run more instances simultaneously.

Before this change, we see peak memory usage while sorting, and most of the memory is in the Phenotypes, which we are done using by then. This'll help the Below lab run stuff, because we're looking at running a relatively high number of instances simultaneously with a low-ish thread count, just because of our hardware sizing.

Massif screenshot, 10k iterations, before this change. How i tracked down the extra memory usage at the end from reporter->sort():
![image](https://user-images.githubusercontent.com/3219141/205676745-4a3359c9-fc20-4d8c-bee8-72679eaa7bf6.png)
