### PR TITLE
Create an environment.yml file for ibdreduce

### DIFF
--- a/ibdreduce_environment.yml
+++ b/ibdreduce_environment.yml
@@ -1,0 +1,57 @@
+name: ibdreduce
+channels:
+  - defaults
+dependencies:
+  - python=3.10
+  - _libgcc_mutex=0.1=main
+  - _openmp_mutex=5.1=1_gnu
+  - appdirs=1.4.4=pyhd3eb1b0_0
+  - blas=1.0=mkl
+  - brotlipy=0.7.0=py310h7f8727e_1002
+  - bzip2=1.0.8=h7b6447c_0
+  - ca-certificates=2023.01.10=h06a4308_0
+  - certifi=2022.12.7=py310h06a4308_0
+  - cffi=1.15.1=py310h5eee18b_3
+  - charset-normalizer=2.0.4=pyhd3eb1b0_0
+  - cryptography=38.0.4=py310h9ce1e76_0
+  - fftw=3.3.9=h27cfd23_1
+  - idna=3.4=py310h06a4308_0
+  - intel-openmp=2021.4.0=h06a4308_3561
+  - ld_impl_linux-64=2.38=h1181459_1
+  - libffi=3.4.2=h6a678d5_6
+  - libgcc-ng=11.2.0=h1234567_1
+  - libgfortran-ng=11.2.0=h00389a5_1
+  - libgfortran5=11.2.0=h1234567_1
+  - libgomp=11.2.0=h1234567_1
+  - libstdcxx-ng=11.2.0=h1234567_1
+  - libuuid=1.41.5=h5eee18b_0
+  - mkl=2021.4.0=h06a4308_640
+  - mkl-service=2.4.0=py310h7f8727e_0
+  - mkl_fft=1.3.1=py310hd6ae3a3_0
+  - mkl_random=1.2.2=py310h00e6091_0
+  - ncurses=6.4=h6a678d5_0
+  - numpy=1.23.5=py310hd5efca6_0
+  - numpy-base=1.23.5=py310h8e6c178_0
+  - openssl=1.1.1t=h7f8727e_0
+  - packaging=22.0=py310h06a4308_0
+  - pip=22.3.1=py310h06a4308_0
+  - pooch=1.4.0=pyhd3eb1b0_0
+  - pycparser=2.21=pyhd3eb1b0_0
+  - pyopenssl=22.0.0=pyhd3eb1b0_0
+  - pysocks=1.7.1=py310h06a4308_0
+  - python=3.10.9=h7a1cb2a_0
+  - readline=8.2=h5eee18b_0
+  - requests=2.28.1=py310h06a4308_0
+  - scipy=1.10.0=py310hd5efca6_0
+  - setuptools=65.6.3=py310h06a4308_0
+  - six=1.16.0=pyhd3eb1b0_1
+  - sqlite=3.40.1=h5082296_0
+  - tk=8.6.12=h1ccaba5_0
+  - tzdata=2022g=h04d1e81_0
+  - urllib3=1.26.14=py310h06a4308_0
+  - wheel=0.38.4=py310h06a4308_0
+  - xz=5.2.10=h5eee18b_1
+  - zlib=1.2.13=h5eee18b_0
+  - zstandard=0.19.0=py310h5eee18b_0
+    
+


### PR DESCRIPTION
Proposed change adds an environment.yml file titled "ibdreduce_environment.yml" file to the main directory of carvaIBD (I didn't see one in the main directory already). This change is proposed because ibdreduce.py is dependent upon dependencies that are not in the standard library such as zstandard, numpy, and scipy so the user needs to install them. The yaml file is for convience so the user can just run "conda env create -f ibdreduce_environment.yml" to install all of the necessary dependencies.

1. This file will create a conda environment called ibdreduce. The user can activate this using the command: "conda activate ibdreduce".

2. This file was create from the below lab's server linux environment which is: Ubuntu 20.04.5 LTS (GNU/Linux 5.4.0-135-generic x86_64). I am not certain if it would work on other OSes but I am assuming this will be running on linux servers

3. I created this with a python=3.10 dependency. I have been running ibdreduce with python 3.10 so the ibdreduce code runs fine in python 3.10. But the dependencies installed by the yaml file are resolved for python 3.10 so they will probably not work with python 3.6 which is the current minimum version required by ibdreduce. I could change this if necessary.