### PR TITLE
Ibdreduce making sure the output file closes

### DIFF
--- a/IBDReduce/ibdreduce_v3.py
+++ b/IBDReduce/ibdreduce_v3.py
@@ -320,19 +320,6 @@ def main():
                 f"{bp_ids[i][0]}\t{bp_ids[i][1]}\t{ibdfrac[i]}\t{empp[i]}\t{lower[i]},{upper[i]}\t{adjp[i]}\t{cutoff}\t{succ[i]}\t{args.nperm * args.nruns}\t{delta[i]}\n"
             )
 
-            # print('{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}'.format(
-            #     bp_ids[i][0],
-            #     bp_ids[i][1],
-            #     ibdfrac[i],
-            #     empp[i],
-            #     '{},{}'.format(lower[i], upper[i]),
-            #     adjp[i],
-            #     cutoff,
-            #     succ[i],
-            #     args.nperm * args.nruns,
-            #     delta[i]
-            # ), file=opf)
-
     ttotal2 = datetime.now()
     print(f"Total runtime: {ttotal2 - ttotal1}")
 


### PR DESCRIPTION
There was a file that was never closed at line 263. I wrapped it within a context manager so that the resource is automatically closed and then converted the print statements to f-strings to be more pythonic. Also black formatted the file so that coding style is consistent.