### PR TITLE
fix IBDBench Build: Set macros for armadillo at build rather than in code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,11 +110,12 @@ target_link_libraries(ibdlib ${Python3_LIBRARIES} ${Boost_LIBRARIES} ${ZLIB_LIBR
 
 add_executable(carvaIBD main.cpp ${PROJECT_SUPPORT_FILES})
 
+target_compile_definitions(carvaIBD PRIVATE ARMA_DONT_USE_WRAPPER=1)
+
 target_link_libraries(carvaIBD fmt::fmt-header-only)
 target_link_libraries(carvaIBD pthread)
 target_link_libraries(carvaIBD ${LAPACK_LIBRARIES})
 target_link_libraries(carvaIBD ${BLAS_LIBRARIES})
-target_link_libraries(carvaIBD ${ARMADILLO_LIBRARIES})
 target_link_libraries(carvaIBD ${Python3_LIBRARIES} ${Boost_LIBRARIES})
 target_link_libraries(carvaIBD ${ZLIB_LIBRARIES})
 if(Gperftools_FOUND)
@@ -125,10 +126,13 @@ target_compile_definitions(carvaIBD PRIVATE MAXCOLORS=10000000)
 
 if(benchmark_FOUND)
     add_executable(ibdBench bench_main.cpp ${PROJECT_SUPPORT_FILES})
+    target_compile_definitions(ibdBench PRIVATE ARMA_DONT_USE_WRAPPER=1)
+
     target_link_libraries(ibdBench benchmark)
     target_link_libraries(ibdBench fmt::fmt-header-only)
     target_link_libraries(ibdBench pthread)
-    target_link_libraries(ibdBench ${ARMADILLO_LIBRARIES})
+    target_link_libraries(ibdBench ${BLAS_LIBRARIES})
+    target_link_libraries(ibdBench ${LAPACK_LIBRARIES})
     target_link_libraries(ibdBench ${Python3_LIBRARIES} ${Boost_LIBRARIES})
     target_link_libraries(ibdBench ${ZLIB_LIBRARIES})
 endif()

--- a/link/family.hpp
+++ b/link/family.hpp
@@ -5,8 +5,6 @@
 #ifndef PERMUTE_ASSOCIATE_LINK_HPP
 #define PERMUTE_ASSOCIATE_LINK_HPP
 
-#define ARMA_DONT_USE_WRAPPER
-
 #include <armadillo>
 
 struct Family {

--- a/src/glm.hpp
+++ b/src/glm.hpp
@@ -5,8 +5,6 @@
 #ifndef PERMUTE_ASSOCIATE_GLM_HPP
 #define PERMUTE_ASSOCIATE_GLM_HPP
 
-#define ARMA_DONT_USE_WRAPPER
-
 #include <armadillo>
 #include <boost/math/tools/toms748_solve.hpp>
 

--- a/src/indexer.hpp
+++ b/src/indexer.hpp
@@ -5,8 +5,6 @@
 #ifndef CARVAIBD_SRC_INDEXER_HPP
 #define CARVAIBD_SRC_INDEXER_HPP
 
-#define ARMA_DONT_USE_WRAPPER
-
 #include "types.hpp"
 #include "indexsort.hpp"
 #include <armadillo>

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -5,8 +5,6 @@
 #ifndef CARVAIBD_PARSER_HPP
 #define CARVAIBD_PARSER_HPP
 
-#define ARMA_DONT_USE_WRAPPER
-
 #include <armadillo>
 #include <optional>
 #include <set>

--- a/src/permutation.cpp
+++ b/src/permutation.cpp
@@ -130,7 +130,8 @@ T Permute<T>::unpack(int successes, int bin_size, bool shuffle,
     if (shuffle) {
         for (int i = r.size() - 1; i >= 1; --i) {
             auto j = rng.IRandom(0, i);
-            std::swap(r[i], r[j]);
+            using std::swap;
+            swap(r[i], r[j]);
         }
     }
     assert(std::accumulate(r.begin(), r.end(), 0) == successes);

--- a/src/permutation.hpp
+++ b/src/permutation.hpp
@@ -5,8 +5,6 @@
 #ifndef PERMUTE_ASSOCIATE_PERMUTATION_HPP
 #define PERMUTE_ASSOCIATE_PERMUTATION_HPP
 
-#define ARMA_DONT_USE_WRAPPER
-
 #include <armadillo>
 #include <memory>
 #include <stocc/stocc.h>

--- a/src/phenotypes.cpp
+++ b/src/phenotypes.cpp
@@ -312,7 +312,8 @@ void Phenotypes<T>::shuffle() {
             for (int j = (*phenotypes)[0].size() - 1; j > 0; j--) {
                 std::uniform_int_distribution<> dis(0, j);
                 int k = dis(gen);
-                std::swap((*phenotypes)[i][j], (*phenotypes)[i][k]);
+                using std::swap;
+                swap((*phenotypes)[i][j], (*phenotypes)[i][k]);
             }
         }
     }

--- a/src/statistic.hpp
+++ b/src/statistic.hpp
@@ -5,8 +5,6 @@
 #ifndef CARVAIBD_STATISTIC_HPP
 #define CARVAIBD_STATISTIC_HPP
 
-#define ARMA_DONT_USE_WRAPPER
-
 #include "breakpoint.hpp"
 #include "indexer.hpp"
 #include "parameters.hpp"


### PR DESCRIPTION
We ran into a build failure of the ibdBench binary on our servers because I misunderstood how Armadillo was being linked. I'm guessing you never build ibdBench because you don't have Google Benchmark installed and available?

Long story short, I hadn't realized that you intended to link Armadillo without the wrapper, i.e. linking straight to BLAS and LAPACK. This moves the configuration to make that happen into the build, so that you don't have to define the macro before importing Armadillo in code.

I also got a build failure related to the std::swap usage on GCC 13.2.0, rather than figure out exactly what's wrong I thought it better to update to best practice: https://quuxplusone.github.io/blog/2020/07/11/the-std-swap-two-step/

These changes:
1. Define the ARMA_DONT_USE_WRAPPER macro to not use Armadillo wrapper in the CMakeLists rather than before importing Armadillo, to avoid edge cases where it was not set.
2. Update some std::swap usage to use the swap 2 step instead, which fixes the build on newer compilers.