### PR TITLE
Accidental bug in phenotype parser

### DIFF
--- a/IBDReduce/ibdreduce_v3.py
+++ b/IBDReduce/ibdreduce_v3.py
@@ -182,8 +182,8 @@ def parse_pheno(ifile: str, phenotype: Optional[str] = None) -> Tuple[int, int]:
                 phenotype_indx = header_list.index(phenotype)
                 continue
             else: # If no phenotype string then we skip the header
-                phenotype_indx = 1 # If no phenotype name is passed then we are going to treat this like a 2 column file where the first column are the ids and the second column is the phenotype status
                 if i == 0:
+                    phenotype_indx = 1 # If no phenotype name is passed then we are going to treat this like a 2 column file where the first column are the ids and the second column is the phenotype status
                     continue
 
             l = l.strip().split()


### PR DESCRIPTION
### Issue:
---
I accidentally introduced a bug in the parse_pheno function. This bug accidentally always set the phenotype column index to 1 no matter what. This bug was causing the phenotype counts to be off. It only affected trying to run IBDReduce with a phenotype matrix. This did not affect running IBDReduce with  a two column phenotype file.

### Fix:
---
I moved the phenotype_indx reassignment into the i==0 if statement so that it would only happen when reading the header line. You could also assign phenotype_indx to 1 before the with statement that opens the file but I think the if/else might be more clear in the future what is happening